### PR TITLE
Clarify definition of SPI_ENABLED

### DIFF
--- a/inc/system.h
+++ b/inc/system.h
@@ -28,6 +28,13 @@
 // apparently this is not working (6/7/2021)
 //#define CLMODE_ENABLED
 
+
+// List of supported SPI configurations
+#define SPI_NONE                0
+#define SPI_STM8_MASTER         1
+#define SPI_STM8_SLAVE          2
+
+
 /**
  * the STM8 variant is defined in the project file, along with the appropriate 
  * compiler settings for the particular MCU (memory model etc.)
@@ -50,7 +57,7 @@
   #define SERVO_GPIO_PIN   GPIO_PIN_4
 
   #define HAS_SERVO_INPUT
-  #define SPI_ENABLED
+  #define SPI_ENABLED      SPI_STM8_MASTER
 
   #define UNDERVOLTAGE_FAULT_ENABLED
 
@@ -74,7 +81,7 @@
   #define SERVO_GPIO_PORT  GPIOC
   #define SERVO_GPIO_PIN   GPIO_PIN_4
 
-  #define SPI_ENABLED
+  #define SPI_ENABLED      SPI_STM8_MASTER
   #define HAS_SERVO_INPUT
 
   #define UNDERVOLTAGE_FAULT_ENABLED
@@ -104,8 +111,8 @@
 //  #define UNDERVOLTAGE_FAULT_ENABLED
 #endif
 
-#if defined( SPI_ENABLED )
-  #define SPI_CONTROLLER
+#ifndef SPI_ENABLED
+#define SPI_ENABLED SPI_NONE
 #endif
 
 #define SPI_RX_BUF_SZ  16 // 256 // tmp

--- a/src/mcu_stm8s.c
+++ b/src/mcu_stm8s.c
@@ -513,7 +513,7 @@ static void Clock_setup(void)
   CLK_PeripheralClockConfig(CLK_PERIPHERAL_TIMER3, ENABLE);
 }
 
-#if defined( SPI_ENABLED )
+#if SPI_ENABLED
 /**
  * @brief  Configure SPI bus
  *
@@ -527,7 +527,7 @@ void SPI_setup(void)
 
   SPI_DeInit();
 
-#ifdef SPI_CONTROLLER
+#if SPI_ENABLED == SPI_STM8_MASTER
 
   // Set GPIO pins to output push-pull high level.
 
@@ -570,7 +570,7 @@ void SPI_setup(void)
   SPI_ITConfig(SPI_IT_RXNE, ENABLE); // Interrupt when the Rx buffer is not empty.
 #endif
 
-#endif // SPI_CONTROLLER
+#endif // SPI_ENABLED == SPI_STM8_MASTER
 
   //Enable SPI.
   SPI_Cmd(ENABLE);
@@ -598,7 +598,7 @@ void MCU_Init(void)
   Servo_CC_setup();
 #endif
 
-#if defined( SPI_ENABLED )
+#if SPI_ENABLED
   SPI_setup();
 #endif
 }

--- a/src/per_task.c
+++ b/src/per_task.c
@@ -382,7 +382,7 @@ uint8_t Task_Ready(void)
 
     if ( ! ((framecount++) % 0x20) )
     {
-#if defined( SPI_ENABLED ) && defined( SPI_CONTROLLER )
+#if SPI_ENABLED == SPI_STM8_MASTER
       SPI_controld();
 #endif
     }

--- a/src/spi_stm8s.c
+++ b/src/spi_stm8s.c
@@ -21,7 +21,7 @@
 // todo consider -DSPI_ENABLED ? in project/makefile
 #include "system.h"
 
-#if defined (SPI_ENABLED)
+#if SPI_ENABLED
 
 // app headers
 #include "mcu_stm8s.h"
@@ -232,5 +232,5 @@ static void SPI_periphd(void)
 }
 #endif
 
-#endif // defined (SPI_ENABLED)
+#endif // SPI_ENABLED
 


### PR DESCRIPTION
Removed SPI_CONTROLLER, and replaced by setting SPI_ENABLED to indicate the enabled SPI driver (or SPI_NONE to disable).